### PR TITLE
Issue 1 mtu

### DIFF
--- a/app/api/hls.py
+++ b/app/api/hls.py
@@ -88,9 +88,6 @@ def _playlist_response(filepath, check_abr_stream=None):
 
 
 def _valid_stream(name):
-    # Allow nested paths (e.g. "live/kyles23") since MediaMTX paths may contain
-    # slashes, but reject traversal ("..") and leading/trailing slashes so the
-    # name stays safely within the HLS output directory.
     return (
         bool(name)
         and len(name) <= 128

--- a/app/api/hls.py
+++ b/app/api/hls.py
@@ -88,7 +88,17 @@ def _playlist_response(filepath, check_abr_stream=None):
 
 
 def _valid_stream(name):
-    return bool(name) and re.match(r'^[a-zA-Z0-9_.-]+$', name) and len(name) <= 128
+    # Allow nested paths (e.g. "live/kyles23") since MediaMTX paths may contain
+    # slashes, but reject traversal ("..") and leading/trailing slashes so the
+    # name stays safely within the HLS output directory.
+    return (
+        bool(name)
+        and len(name) <= 128
+        and re.match(r'^[a-zA-Z0-9_./-]+$', name) is not None
+        and '..' not in name
+        and not name.startswith('/')
+        and not name.endswith('/')
+    )
 
 
 # ------------------------------------------------------------------

--- a/app/api/streams.py
+++ b/app/api/streams.py
@@ -305,6 +305,24 @@ def _resolve_source_info(source: dict | None, conn_map: dict | None = None) -> d
     return {'protocol': protocol, 'sourceAddress': address}
 
 
+# Codecs MediaMTX can package directly into HLS (mirrors MediaMTX's own
+# supported-codec list). A source whose tracks are none of these — most
+# commonly an opaque "MPEG-TS" track from an ATAK/drone publisher — cannot be
+# HLS-muxed natively and must be transcoded (via ABR/FFmpeg) for browser playback.
+HLS_MUXABLE_CODECS = {'AV1', 'VP9', 'H265', 'H264', 'Opus', 'MPEG-4 Audio'}
+
+
+def _needs_transcode(tracks: list) -> bool:
+    """True if MediaMTX cannot natively HLS-mux this source's tracks.
+
+    Returns False when tracks are unknown (empty) so callers fall back to the
+    normal proxy path and its reactive transcode fallback.
+    """
+    if not tracks:
+        return False
+    return not any(track in HLS_MUXABLE_CODECS for track in tracks)
+
+
 def _extract_stream_info(path_name: str, path_info: dict, conn_map: dict | None = None) -> dict:
     """Extract stream info from a MediaMTX path entry (deduplicates list/dict handling)."""
     readers = path_info.get('readers', [])
@@ -352,6 +370,8 @@ def _extract_stream_info(path_name: str, path_info: dict, conn_map: dict | None 
     else:
         last_data_time = prev['last_change']
 
+    tracks = path_info.get('tracks') or []
+
     return {
         'name': path_name,
         'ready': path_info.get('ready', False),
@@ -362,6 +382,8 @@ def _extract_stream_info(path_name: str, path_info: dict, conn_map: dict | None 
         'protocol': source_info['protocol'],
         'sourceAddress': source_info['sourceAddress'],
         'sourceUrl': source_url,
+        'tracks': tracks,
+        'needsTranscode': _needs_transcode(tracks),
         'lastDataTime': datetime.fromtimestamp(last_data_time, tz=timezone.utc).isoformat() if bytes_received > 0 else None,
     }
 

--- a/app/api/streams.py
+++ b/app/api/streams.py
@@ -305,19 +305,10 @@ def _resolve_source_info(source: dict | None, conn_map: dict | None = None) -> d
     return {'protocol': protocol, 'sourceAddress': address}
 
 
-# Codecs MediaMTX can package directly into HLS (mirrors MediaMTX's own
-# supported-codec list). A source whose tracks are none of these — most
-# commonly an opaque "MPEG-TS" track from an ATAK/drone publisher — cannot be
-# HLS-muxed natively and must be transcoded (via ABR/FFmpeg) for browser playback.
 HLS_MUXABLE_CODECS = {'AV1', 'VP9', 'H265', 'H264', 'Opus', 'MPEG-4 Audio'}
 
 
 def _needs_transcode(tracks: list) -> bool:
-    """True if MediaMTX cannot natively HLS-mux this source's tracks.
-
-    Returns False when tracks are unknown (empty) so callers fall back to the
-    normal proxy path and its reactive transcode fallback.
-    """
     if not tracks:
         return False
     return not any(track in HLS_MUXABLE_CODECS for track in tracks)

--- a/app/services/abr.py
+++ b/app/services/abr.py
@@ -483,8 +483,10 @@ class ABRManager:
         # Redirect stderr to a log file instead of PIPE to prevent deadlock.
         # subprocess.PIPE has a ~64KB OS buffer; if FFmpeg fills it and nobody
         # reads, FFmpeg blocks on write() and the stream freezes.
-        os.makedirs(FFMPEG_LOG_DIR, exist_ok=True)
         log_path = os.path.join(FFMPEG_LOG_DIR, f'{stream_name}.log')
+        # dirname (not FFMPEG_LOG_DIR) so nested stream names like "live/kyles23"
+        # get their parent directory created too.
+        os.makedirs(os.path.dirname(log_path), exist_ok=True)
         try:
             stderr_file = open(log_path, 'w')
         except OSError as e:

--- a/app/services/abr.py
+++ b/app/services/abr.py
@@ -484,8 +484,6 @@ class ABRManager:
         # subprocess.PIPE has a ~64KB OS buffer; if FFmpeg fills it and nobody
         # reads, FFmpeg blocks on write() and the stream freezes.
         log_path = os.path.join(FFMPEG_LOG_DIR, f'{stream_name}.log')
-        # dirname (not FFMPEG_LOG_DIR) so nested stream names like "live/kyles23"
-        # get their parent directory created too.
         os.makedirs(os.path.dirname(log_path), exist_ok=True)
         try:
             stderr_file = open(log_path, 'w')

--- a/web/static/videowall.html
+++ b/web/static/videowall.html
@@ -173,19 +173,43 @@ This is distributed in the hope that it will be useful, but without any warranty
         async function loadCell(idx, streamName) {
             destroyCell(idx);
             if (!streamName) return;
-            // Use ABR path if transcoding is already running (e.g. MPEG-TS source
-            // that MediaMTX cannot natively HLS-mux), otherwise proxy MediaMTX HLS.
-            let src;
+
+            // Some sources (notably MPEG-TS from ATAK/drone publishers) carry no
+            // codec MediaMTX can HLS-mux, so its native HLS 404s. The server flags
+            // these via needsTranscode; route them straight to the ABR/FFmpeg
+            // transcode instead of wasting a round-trip on the proxy.
+            const meta = lastStreams.find(s => s.name === streamName);
+            const needsTranscode = !!(meta && meta.needsTranscode);
+
             let abrRunning = false;
             try {
                 const resp = await fetch(`/api/streams/${encodeURIComponent(streamName)}/abr/status`);
                 const data = resp.ok ? await resp.json() : {};
                 abrRunning = !!data.running;
             } catch { /* fall through */ }
-            src = abrRunning
+
+            if (needsTranscode && !abrRunning) {
+                // Kick off transcoding up front, then load the master playlist once
+                // FFmpeg has had time to produce its first segment.
+                const { overlay, video, status } = cells[idx];
+                overlay.textContent = 'Transcoding…';
+                overlay.className = 'vw-overlay active';
+                video.style.display = 'none';
+                status.style.display = 'none';
+                try {
+                    await fetch(`/api/streams/${encodeURIComponent(streamName)}/abr`, { method: 'POST' });
+                } catch { /* error handler in _loadCellWithSrc will retry */ }
+                setTimeout(() => {
+                    _loadCellWithSrc(idx, streamName, `/hls/${encodeURIComponent(streamName)}/master.m3u8`, true);
+                }, 6000);
+                return;
+            }
+
+            const useTranscode = abrRunning || needsTranscode;
+            const src = useTranscode
                 ? `/hls/${encodeURIComponent(streamName)}/master.m3u8`
                 : `/api/hls/proxy/${encodeURIComponent(streamName)}/index.m3u8?videoonly=1`;
-            _loadCellWithSrc(idx, streamName, src, abrRunning);
+            _loadCellWithSrc(idx, streamName, src, useTranscode);
         }
 
         function _loadCellWithSrc(idx, streamName, src, isTranscodeFallback) {

--- a/web/static/videowall.html
+++ b/web/static/videowall.html
@@ -174,10 +174,6 @@ This is distributed in the hope that it will be useful, but without any warranty
             destroyCell(idx);
             if (!streamName) return;
 
-            // Some sources (notably MPEG-TS from ATAK/drone publishers) carry no
-            // codec MediaMTX can HLS-mux, so its native HLS 404s. The server flags
-            // these via needsTranscode; route them straight to the ABR/FFmpeg
-            // transcode instead of wasting a round-trip on the proxy.
             const meta = lastStreams.find(s => s.name === streamName);
             const needsTranscode = !!(meta && meta.needsTranscode);
 
@@ -189,8 +185,6 @@ This is distributed in the hope that it will be useful, but without any warranty
             } catch { /* fall through */ }
 
             if (needsTranscode && !abrRunning) {
-                // Kick off transcoding up front, then load the master playlist once
-                // FFmpeg has had time to produce its first segment.
                 const { overlay, video, status } = cells[idx];
                 overlay.textContent = 'Transcoding…';
                 overlay.className = 'vw-overlay active';
@@ -198,7 +192,7 @@ This is distributed in the hope that it will be useful, but without any warranty
                 status.style.display = 'none';
                 try {
                     await fetch(`/api/streams/${encodeURIComponent(streamName)}/abr`, { method: 'POST' });
-                } catch { /* error handler in _loadCellWithSrc will retry */ }
+                } catch {}
                 setTimeout(() => {
                     _loadCellWithSrc(idx, streamName, `/hls/${encodeURIComponent(streamName)}/master.m3u8`, true);
                 }, 6000);


### PR DESCRIPTION
Problem: MediaMTX can't create an HLS muxer for sources published as a single opaque MPEG-TS track, since MPEG-TS is a container, not a supported codec. The Video Wall only transcoded reactively (after hls.js failed), and nested stream paths like live/myvideo

Changes:

streams.py — /api/streams now reports MediaMTX tracks and a needsTranscode flag (true when no track is in MediaMTX's HLS-muxable codec set).
videowall.html — when needsTranscode is set, start ABR/FFmpeg transcoding up front and load the master playlist directly, instead of waiting for a failed proxy request. Existing streams and the error fallback are unchanged.
hls.py — allow slashes in stream names (_valid_stream), fixing the 400 on nested paths like /hls/live%2Fmyvideo/master.m3u8; still blocks .. traversal.
abr.py — create the FFmpeg log file's parent dir so nested names (ffmpeg/live/myvideo.log) don't fail.